### PR TITLE
Tetherport offset to avoid collisions

### DIFF
--- a/CODE/EncryptoidModPack/EmpyrionModdingFramework/EmpyrionModdingFramework.csproj
+++ b/CODE/EncryptoidModPack/EmpyrionModdingFramework/EmpyrionModdingFramework.csproj
@@ -80,6 +80,7 @@
     <Compile Include="PlayerInfoExtensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RequestManager.cs" />
+    <Compile Include="Teleport\PortalOffsetRecord.cs" />
     <Compile Include="Teleport\PortalRecord.cs" />
     <Compile Include="Teleport\PlayerLocationRecord.cs" />
   </ItemGroup>

--- a/CODE/EncryptoidModPack/EmpyrionModdingFramework/Teleport/PortalOffsetRecord.cs
+++ b/CODE/EncryptoidModPack/EmpyrionModdingFramework/Teleport/PortalOffsetRecord.cs
@@ -1,0 +1,23 @@
+﻿namespace EmpyrionModdingFramework.Teleport
+{
+    public class PortalOffsetRecord
+    {
+        public PortalOffsetRecord() { } // For CsvHelper?
+
+        /// <summary>
+        /// The name of the PortalRecord entry
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// The radius of the circle to build points on
+        /// </summary>
+        public int Radius { get; set; }
+        
+        /// <summary>
+        /// How many warp in points we should make on the created circle
+        /// </summary>
+
+        public int Count { get; set; }
+    }
+}

--- a/CODE/EncryptoidModPack/EncryptoidModPack/EncryptoidModPack.csproj
+++ b/CODE/EncryptoidModPack/EncryptoidModPack/EncryptoidModPack.csproj
@@ -109,5 +109,8 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="SampleEncryptoidDatabase\Tetherport\Database\portal.offsets.tether" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/CODE/EncryptoidModPack/EncryptoidModPack/SampleEncryptoidDatabase/Tetherport/Database/portal.offsets.tether
+++ b/CODE/EncryptoidModPack/EncryptoidModPack/SampleEncryptoidDatabase/Tetherport/Database/portal.offsets.tether
@@ -1,0 +1,1 @@
+Name,Radius,Count

--- a/CODE/EncryptoidModPack/Tetherport/Tetherport.csproj
+++ b/CODE/EncryptoidModPack/Tetherport/Tetherport.csproj
@@ -53,6 +53,7 @@
     <Compile Include="TetherportFormatter.cs" />
     <Compile Include="TetherportBasicHandler.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TetherportTargetHelper.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\EmpyrionModdingFramework\EmpyrionModdingFramework.csproj">

--- a/CODE/EncryptoidModPack/Tetherport/TetherportBasicHandler.cs
+++ b/CODE/EncryptoidModPack/Tetherport/TetherportBasicHandler.cs
@@ -173,7 +173,7 @@ namespace Tetherport
             var isSitting = player.IsSeated();
 
             //This is intentionally not awaited as there is a task delay after
-            _modFramework.MessagePlayer(player.entityId,
+            _ = _modFramework.MessagePlayer(player.entityId,
                 $"Initiating Tetherport. {_config.TetherportDelay} seconds to launch.", _config.TetherportDelay);
             await Task.Delay(new TimeSpan(0, 0, _config.TetherportDelay));
 

--- a/CODE/EncryptoidModPack/Tetherport/TetherportBasicHandler.cs
+++ b/CODE/EncryptoidModPack/Tetherport/TetherportBasicHandler.cs
@@ -20,6 +20,7 @@ namespace Tetherport
         private readonly EmpyrionModdingFrameworkBase _modFramework;
         private readonly Action<string> _log;
         private readonly TetherportConfig _config;
+        private readonly TetherportTargetHelper _targetHelper;
 
         private const string PortalFileName = "portal.tether";
         private const string UntetherLocationName = "UNTETHER";
@@ -36,6 +37,7 @@ namespace Tetherport
             _modFramework = modFramework;
             _log = logFunc;
             _config = config;
+            _targetHelper = new TetherportTargetHelper(_dbManager, _log);
         }
 
         public async Task ListPortals(MessageData messageData)
@@ -196,24 +198,25 @@ namespace Tetherport
                 _dbManager.SaveRecord(TetherportFormatter.FormatTetherportFileName(player.steamId), player.ToPlayerLocationRecord(), true);
             }
  
-            var portals = _dbManager.LoadRecords<PortalRecord>(PortalFileName);
-            if (portals == null)
+            var portal = _dbManager
+                .LoadRecords<PortalRecord>(PortalFileName)?
+                .FirstOrDefault(record => record.Name == linkId);
+
+            if (portal == null)
             {
-                await _modFramework.MessagePlayer(player.entityId, $"Could not find Tetherport Locations.", 10, MessagerPriority.Red);
+                await _modFramework.MessagePlayer(player.entityId, $"Could not find Tetherport Location.", 10, MessagerPriority.Red);
                 return;
             }
 
-            // Find matching record and teleport player
-            foreach (var portal in portals)
-            {
-                if (string.Equals(portal.Name, linkId))
-                {
-                    //Teleport and inform player
-                    await _modFramework.TeleportPlayer(player.entityId, portal.Playfield, portal.PosX, portal.PosY, portal.PosZ, portal.RotX, portal.RotY, portal.RotZ);
-                    await _modFramework.MessagePlayer(player.entityId, $"Created Tetherport tether! Welcome to {portal.Name}!", 10);
-                    return;
-                }
-            }
+            var coordinates = _targetHelper.GetCoordinates(portal);
+
+            await _modFramework.TeleportPlayer(
+                player.entityId, 
+                portal.Playfield, 
+                coordinates.X, coordinates.Y, coordinates.Z, 
+                portal.RotX, portal.RotY, portal.RotZ);
+
+            await _modFramework.MessagePlayer(player.entityId, $"Created Tetherport tether! Welcome to {portal.Name}!", 10);
         }
     }
 }

--- a/CODE/EncryptoidModPack/Tetherport/TetherportTargetHelper.cs
+++ b/CODE/EncryptoidModPack/Tetherport/TetherportTargetHelper.cs
@@ -1,0 +1,162 @@
+﻿using EmpyrionModdingFramework.Database;
+using EmpyrionModdingFramework.Teleport;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Tetherport
+{
+    internal class TetherportTargetHelper
+    {
+        private static readonly ConcurrentDictionary<string, WarpLocations> _cachedWarpLocations = new ConcurrentDictionary<string, WarpLocations>();
+
+        private readonly IDatabaseManager _dbManager;
+        private readonly Action<string> _log;
+
+        private const string PortalOffsetFileName = "portal.offsets.tether";
+
+        public TetherportTargetHelper(IDatabaseManager dbManager, Action<string> logFunc)
+        {
+            _dbManager = dbManager;
+            _log = logFunc;
+        }
+
+        public Vector3<float> GetCoordinates(PortalRecord record)
+        {
+            var offsetRecord = _dbManager
+                .LoadRecords<PortalOffsetRecord>(PortalOffsetFileName)
+                ?.FirstOrDefault(x => record.Name == x.Name);
+
+            if (offsetRecord == null)
+            {
+                _cachedWarpLocations.TryRemove(record.Name, out var _);
+                return new Vector3<float>(record.PosX, record.PosY, record.PosZ);
+            }
+
+            var points = _cachedWarpLocations.AddOrUpdate(record.Name,
+                name =>
+                {
+                    return new WarpLocations(
+                        new Vector3<float>(record.PosX, record.PosY, record.PosZ),
+                        offsetRecord.Radius,
+                        offsetRecord.Count);
+                },
+                (name, current) =>
+                {
+                    if (current.IsValid(record, offsetRecord))
+                        return current;
+
+                    return new WarpLocations(
+                        new Vector3<float>(record.PosX, record.PosY, record.PosZ),
+                        offsetRecord.Radius,
+                        offsetRecord.Count);
+                });
+
+            var next = points.NextLocation;
+#if DEBUG
+            _log($"Tetherport Coordinate Override - Name: {offsetRecord.Name}, Radius: {offsetRecord.Radius}, Count: {offsetRecord.Count}, Next: {next}");
+            _log($"Tetherport Coordinate Override - Calculated Locations: {string.Join(", ", points.Locations)}");
+#endif
+
+            return next;
+        }
+
+        public readonly struct Vector3<T> : IEquatable<Vector3<T>>
+        {
+            public T X { get; }
+            public T Y { get; }
+            public T Z { get; }
+
+            public Vector3(T x, T y, T z)
+            {
+                X = x;
+                Y = y;
+                Z = z;
+            }
+
+            public override string ToString()
+            {
+                return $"Vec<{typeof(T).Name}>[X: {X}, Y: {Y}, Z: {Z}]";
+            }
+
+            public override bool Equals(object other)
+            {
+                return other is Vector3<T> vector && Equals(vector);
+            }
+
+            public bool Equals(Vector3<T> other)
+            {
+                return EqualityComparer<T>.Default.Equals(X, other.X) &&
+                       EqualityComparer<T>.Default.Equals(Y, other.Y) &&
+                       EqualityComparer<T>.Default.Equals(Z, other.Z);
+            }
+
+            public override int GetHashCode()
+            {
+                int hashCode = -307843816;
+                hashCode = hashCode * -1521134295 + EqualityComparer<T>.Default.GetHashCode(X);
+                hashCode = hashCode * -1521134295 + EqualityComparer<T>.Default.GetHashCode(Y);
+                hashCode = hashCode * -1521134295 + EqualityComparer<T>.Default.GetHashCode(Z);
+                return hashCode;
+            }
+
+            public static bool operator ==(Vector3<T> left, Vector3<T> right)
+            {
+                return left.Equals(right);
+            }
+
+            public static bool operator !=(Vector3<T> left, Vector3<T> right)
+            {
+                return !(left == right);
+            }
+        }
+
+        private class WarpLocations
+        {
+            private readonly Vector3<float> _center;
+            private readonly int _radius;
+            private readonly List<Vector3<float>> _locations = new List<Vector3<float>>();
+            private int _index = 0;
+
+            public IReadOnlyList<Vector3<float>> Locations => _locations;
+
+            public Vector3<float> NextLocation
+            {
+                get
+                {
+                    if (++_index >= _locations.Count)
+                        _index = 0;
+
+                    return _locations[_index];
+                }
+            }
+
+            public WarpLocations(Vector3<float> center, int radius, int count)
+            {
+                _center = center;
+                _radius = radius;
+
+                var arcLength = (2 * Math.PI * radius) / count;
+                var angle = arcLength / radius;
+                var currentAngle = 0d;
+
+                for (var i = 0; i < count; i++)
+                {
+                    var x = center.X + radius * Math.Cos(currentAngle);
+                    var z = center.Z + radius * Math.Sin(currentAngle);
+
+                    _locations.Add(new Vector3<float>((float)x, center.Y, (float)z));
+
+                    currentAngle += angle;
+                }
+            }
+
+            public bool IsValid(PortalRecord portal, PortalOffsetRecord offset)
+            {
+                return _center.X == portal.PosX && _center.Y == portal.PosY && _center.Z == portal.PosZ &&
+                    _radius == offset.Radius && Locations.Count == offset.Count;
+            }
+        }
+    }
+}


### PR DESCRIPTION
This is modification to how tetherport chooses destination coordinates to avoid collisions.

### Overview

By adding a portal name, radius (in game meters), and count into `portal.offsets.tether` (located in the same directory as `portal.tether`) the destination coordinates for the specified portal will be overridden. Using a radius and count we can create a list (with count entries) of new coordinates in a circle around the portal's real destination. Each tetherport request will cycle around that list to avoid player collisions.

If there is no entry for the portal in `portal.offsets.tether` it will work as normal, going to it's set location.

### Issues & Possible Changes
- I couldn't figure out how to add a DialogueBox which both accepts input (radius/count) while letting you select which portal to assign them to.
- I am unsure how exactly you want all of the binary files in the repo handled so I omitted them from this PR